### PR TITLE
Add option to pass a target stage for multistage Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Things to look out for:
 | Name                  | Required | Default | Description      |
 | --------------------- | -------- | ------- | ---------------- |
 | `context`             | ❌       | .       | Relative path to the build context |
+| `target`              | ❌       |         | Target for [multistage builds](https://docs.docker.com/develop/develop-images/multistage-build/) |
 | `dockerfile`          | ✔        |         | Relative path to your Dockerfile |
 | `image`               | ✔        |         | The name of the image in [Container Registry format](https://cloud.google.com/container-registry/docs/pushing-and-pulling#add-registry) |
 | `service_account_key` | ✔        |         | Base64-encoded service account JSON key |

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   context:
     description: 'path to the build context, defaults to . if not provided'
     required: false
+  target:
+    description: 'which stage to build, if using multistage docker builds'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,13 +8,13 @@ if [ -z "$INPUT_CONTEXT" ]; then
     INPUT_CONTEXT="."
 fi
 
-if [ -z "$INPUT_TARGET" ]; then
-    docker build -f "$INPUT_DOCKERFILE" -t "$INPUT_IMAGE" "$INPUT_CONTEXT"
-else
-    docker build -f "$INPUT_DOCKERFILE" -t "$INPUT_IMAGE"  "$INPUT_CONTEXT" --target "$INPUT_TARGET" 
+if [ "$INPUT_TARGET" ]; then
+    TARGET="--target ${INPUT_TARGET}"
 fi
 
+echo docker build -f "$INPUT_DOCKERFILE" -t "$INPUT_IMAGE"  "$INPUT_CONTEXT" $TARGET
 
+docker build -f "$INPUT_DOCKERFILE" -t "$INPUT_IMAGE"  "$INPUT_CONTEXT" $TARGET
 
 gcloud auth activate-service-account --key-file="$HOME"/gcloud.json --project "$INPUT_PROJECT_ID"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,13 @@ if [ -z "$INPUT_CONTEXT" ]; then
     INPUT_CONTEXT="."
 fi
 
-docker build -f "$INPUT_DOCKERFILE" -t "$INPUT_IMAGE" "$INPUT_CONTEXT"
+if [ -z "$INPUT_TARGET" ]; then
+    docker build -f "$INPUT_DOCKERFILE" -t "$INPUT_IMAGE" "$INPUT_CONTEXT"
+else
+    docker build -f "$INPUT_DOCKERFILE" -t "$INPUT_IMAGE"  "$INPUT_CONTEXT" --target "$INPUT_TARGET" 
+fi
+
+
 
 gcloud auth activate-service-account --key-file="$HOME"/gcloud.json --project "$INPUT_PROJECT_ID"
 


### PR DESCRIPTION
This PR adds the ability to build [multistage Dockerfiles](https://docs.docker.com/develop/develop-images/multistage-build/) by passing the `target` variable.

This is useful because it allows a single Dockerfile to describe a series of images, each inheriting from the previous. 

For example, we use it to define an `analysis` image which includes the base image for our data API but adds some expensive analysis dependencies (e.g. jupyter, plotting libraries) that we don't want to package in the API image.