### PR TITLE
Authenticate before building the Docker image

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,10 +17,10 @@ if [ "$INPUT_BUILD_ARGS" ]; then
     BUILD_ARGS="--build-arg $(echo $BUILD_ARGS_SPLIT | xargs | sed 's/ / --build-arg /g')"
 fi
 
-docker build -f "$INPUT_DOCKERFILE" -t "$INPUT_IMAGE" $BUILD_ARGS "$INPUT_CONTEXT" $TARGET
-
 gcloud auth activate-service-account --key-file="$HOME"/gcloud.json --project "$INPUT_PROJECT_ID"
 
 gcloud auth configure-docker
+
+docker build -f "$INPUT_DOCKERFILE" -t "$INPUT_IMAGE" $BUILD_ARGS "$INPUT_CONTEXT" $TARGET
 
 docker push $INPUT_IMAGE


### PR DESCRIPTION
This change would allow users to build images that are based on images living in GCR.

At the moment, when trying to build a Docker image that has a base image hosted in GCR, the action fails, since authentication hasn't happened yet. 